### PR TITLE
Added md5sums and cleaned up the list files for dpkg packages

### DIFF
--- a/metadata_tiny_stack_test.go
+++ b/metadata_tiny_stack_test.go
@@ -122,6 +122,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/base-files.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/ca-certificates", SatisfyAll(
 				ContainSubstring("Package: ca-certificates"),
 				MatchRegexp("Version: [0-9]+"),
@@ -131,6 +133,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/ca-certificates.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/ca-certificates.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libc6", SatisfyAll(
 				ContainSubstring("Package: libc6"),
@@ -144,6 +148,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/libc6.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libssl3t64", SatisfyAll(
 				ContainSubstring("Package: libssl3t64"),
 				MatchRegexp("Version: [0-9\\.\\-]+ubuntu[0-9\\.]+"),
@@ -156,6 +162,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/libssl3t64.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/netbase", SatisfyAll(
 				ContainSubstring("Package: netbase"),
 				MatchRegexp("Version: [0-9\\.]+"),
@@ -165,6 +173,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/netbase.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/netbase.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/openssl", SatisfyAll(
 				ContainSubstring("Package: openssl"),
@@ -178,6 +188,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/openssl.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/tzdata", SatisfyAll(
 				ContainSubstring("Package: tzdata"),
 				MatchRegexp("Version: [a-z0-9\\.\\-]+ubuntu[0-9\\.]+"),
@@ -187,6 +199,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/tzdata.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/tzdata.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/zlib1g", SatisfyAll(
 				ContainSubstring("Package: zlib1g"),
@@ -199,6 +213,8 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/zlib1g.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/zlib1g.md5sums"))
 
 			Expect(image).NotTo(HaveFile("/usr/share/ca-certificates"))
 

--- a/stacks/noble-tiny-stack/run/run.Dockerfile
+++ b/stacks/noble-tiny-stack/run/run.Dockerfile
@@ -24,11 +24,12 @@ RUN apt download $packages \
     && for pkg in $packages; do \
       dpkg-deb --field $pkg*.deb > /tiny/var/lib/dpkg/status.d/$pkg \
       && dpkg-deb --extract $pkg*.deb /tiny \
-      && dpkg-deb -c $pkg*.deb | \
-        sed -e 's| -> .*||' \
-            -e 's|.* ||p' | \
-        sed -e 's|^\./|/|' \
-            -e 's|^/$|/.|' > /tiny/var/lib/dpkg/info/$pkg.list; \
+      && dpkg-deb -c $pkg*.deb | awk '{print substr($6, 2)}' > /tiny/var/lib/dpkg/info/$pkg.list \
+      && sed -i '1s|.*|/.|' /tiny/var/lib/dpkg/info/$pkg.list \
+      && sed -i '/\/$/s|/$||' /tiny/var/lib/dpkg/info/$pkg.list \
+      && dpkg-deb -e $pkg*.deb MD5SUMS \
+      && cp MD5SUMS/md5sums /tiny/var/lib/dpkg/info/$pkg.md5sums \
+      && rm -rf MD5SUMS; \
     done
 
 RUN ./install-certs.sh


### PR DESCRIPTION
## Summary
This is a continuation of scanner related issues with the tiny image. This change does the following

- Cleans up the list file creation by doing 3 steps
  - Creates the list file using `dpkg-deb -c $pkg*.deb | awk '{print substr($6, 2)}'`
  - Replaces the first line with "/."
  - Removes the final "/" from all lines that end with a "/"
- Creates the $pkg.md5sums file by using the command `dpkg-deb -e $pkg*.deb MD5SUMS`
- Added test cases to address these changes.

This PR should address what is mentioned in the following issue (https://github.com/paketo-buildpacks/jammy-tiny-stack/issues/153)

This is the PR for Jammy Tiny Stack related to this PR (https://github.com/paketo-buildpacks/jammy-tiny-stack/pull/190)

## Use Cases
These changes will hopefully address the issues from scanning tiny images with false positives with CVEs.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
