### PR TITLE
Allow Syft to read deb files appropriately instead of misclassifying as binary

### DIFF
--- a/metadata_tiny_stack_test.go
+++ b/metadata_tiny_stack_test.go
@@ -122,7 +122,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/base-files.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/base-files.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/ca-certificates", SatisfyAll(
 				ContainSubstring("Package: ca-certificates"),
@@ -134,7 +134,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/ca-certificates.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/ca-certificates.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libc6", SatisfyAll(
 				ContainSubstring("Package: libc6"),
@@ -148,7 +148,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/libc6.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/libc6.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libssl3t64", SatisfyAll(
 				ContainSubstring("Package: libssl3t64"),
@@ -162,7 +162,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/libssl3t64.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/libssl3t64.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/netbase", SatisfyAll(
 				ContainSubstring("Package: netbase"),
@@ -174,7 +174,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/netbase.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/netbase.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/openssl", SatisfyAll(
 				ContainSubstring("Package: openssl"),
@@ -188,7 +188,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/openssl.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/openssl.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/tzdata", SatisfyAll(
 				ContainSubstring("Package: tzdata"),
@@ -200,7 +200,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/tzdata.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/tzdata.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/zlib1g", SatisfyAll(
 				ContainSubstring("Package: zlib1g"),
@@ -214,7 +214,7 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
-			Expect(image).To(HaveFile("/var/lib/dpkg/info/zlib1g.md5sums"))
+			Expect(image).To(HaveFile("/var/lib/dpkg/status.d/zlib1g.md5sums"))
 
 			Expect(image).NotTo(HaveFile("/usr/share/ca-certificates"))
 

--- a/stacks/noble-tiny-stack/run/run.Dockerfile
+++ b/stacks/noble-tiny-stack/run/run.Dockerfile
@@ -27,9 +27,9 @@ RUN apt download $packages \
       && dpkg-deb -c $pkg*.deb | awk '{print substr($6, 2)}' > /tiny/var/lib/dpkg/info/$pkg.list \
       && sed -i '1s|.*|/.|' /tiny/var/lib/dpkg/info/$pkg.list \
       && sed -i '/\/$/s|/$||' /tiny/var/lib/dpkg/info/$pkg.list \
-      && dpkg-deb -e $pkg*.deb MD5SUMS \
-      && cp MD5SUMS/md5sums /tiny/var/lib/dpkg/info/$pkg.md5sums \
-      && rm -rf MD5SUMS; \
+      && dpkg-deb --control $pkg*.deb CONTROL \
+      && cp CONTROL/md5sums /tiny/var/lib/dpkg/status.d/$pkg.md5sums \
+      && rm -rf CONTROL; \
     done
 
 RUN ./install-certs.sh


### PR DESCRIPTION
## Summary
Syft reads deb files by either reading the `/var/lib/dpkg/status.d/` directory or the `/var/lib/dpkg/status` file. When the status file is used, it looks for .list and .md5sums files in the `/var/lib/dpkg/info/` directory. When status.d directory is used it looks for .md5sums in the `/var/lib/dpkg/status.d/` directory.

This PR addresses this issue and puts the md5sums file in this folder which reflects the typical Distroless build. While this fixes Syft, Aquasec/Trivy does not use the md5sums file and looks only for the existence of the .list file in the `/var/lib/dpkg/info/` directory. An issue has been filed with Aquasec and an issue filed with Syft (https://github.com/anchore/syft/issues/3912) to see if we can create a unified standard for this. But this PR for the moment addresses both frameworks while waiting until a standard is specified.

This is a clone of https://github.com/paketo-buildpacks/jammy-tiny-stack/pull/193

## Use Cases
This will correct incorrectly labeled CVEs by looking at the deb version vs the binary version.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
