### PR TITLE
Change the gid to 1001

### DIFF
--- a/metadata_base_stack_test.go
+++ b/metadata_base_stack_test.go
@@ -87,16 +87,16 @@ func testMetadataBaseStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(buildReleaseDate).NotTo(BeZero())
 
 			Expect(image).To(SatisfyAll(
-				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1001:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1001::/home/cnb:/bin/bash")),
 				HaveDirectory("/home/cnb"),
 			))
 
-			Expect(file.Config.User).To(Equal("1001:1000"))
+			Expect(file.Config.User).To(Equal("1001:1001"))
 
 			Expect(file.Config.Env).To(ContainElements(
 				"CNB_USER_ID=1001",
-				"CNB_GROUP_ID=1000",
+				"CNB_GROUP_ID=1001",
 				"CNB_STACK_ID=io.buildpacks.stacks.noble",
 			))
 
@@ -177,11 +177,11 @@ func testMetadataBaseStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDate).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1002:1001"))
 
 			Expect(image).To(SatisfyAll(
-				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1001:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1001::/home/cnb:/bin/bash")),
 				HaveDirectory("/home/cnb"),
 			))
 

--- a/metadata_static_stack_test.go
+++ b/metadata_static_stack_test.go
@@ -93,11 +93,11 @@ func testMetadataStaticStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDate).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1002:1001"))
 
 			Expect(image).To(SatisfyAll(
-				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/sbin/nologin")),
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1001:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1001::/home/cnb:/sbin/nologin")),
 				HaveDirectory("/home/cnb"),
 			))
 

--- a/metadata_tiny_stack_test.go
+++ b/metadata_tiny_stack_test.go
@@ -93,11 +93,11 @@ func testMetadataTinyStack(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDate).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1002:1001"))
 
 			Expect(image).To(SatisfyAll(
-				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/sbin/nologin")),
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1001:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1001::/home/cnb:/sbin/nologin")),
 				HaveDirectory("/home/cnb"),
 			))
 

--- a/stacks/noble-base-stack/stack.toml
+++ b/stacks/noble-base-stack/stack.toml
@@ -7,7 +7,7 @@ platforms = ["linux/amd64", "linux/arm64"]
 [build]
   description = "ubuntu:noble with compilers and shell utilities"
   dockerfile = "./build.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/bin/bash"
   uid = 1001
 
@@ -60,7 +60,7 @@ Components: main universe multiverse
 [run]
   description = "ubuntu:noble with some common dependencies like tzdata and openssl"
   dockerfile = "./run.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/bin/bash"
   uid = 1002
 

--- a/stacks/noble-static-stack/stack.toml
+++ b/stacks/noble-static-stack/stack.toml
@@ -7,7 +7,7 @@ platforms = ["linux/amd64", "linux/arm64"]
 [build]
   description = "ubuntu:noble with compilers and shell utilities"
   dockerfile = "./build.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/bin/bash"
   uid = 1001
 
@@ -58,7 +58,7 @@ Components: main universe multiverse
 [run]
   description = "noble for statically-linked applications containing tzdata and ca-certificates"
   dockerfile = "./run/run.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/sbin/nologin"
   uid = 1002
 

--- a/stacks/noble-tiny-stack/stack.toml
+++ b/stacks/noble-tiny-stack/stack.toml
@@ -7,7 +7,7 @@ platforms = ["linux/amd64", "linux/arm64"]
 [build]
   description = "ubuntu:noble with compilers and shell utilities"
   dockerfile = "./build.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/bin/bash"
   uid = 1001
 
@@ -58,7 +58,7 @@ Components: main universe multiverse
 [run]
   description = "distroless-like noble"
   dockerfile = "./run/run.Dockerfile"
-  gid = 1000
+  gid = 1001
   shell = "/sbin/nologin"
   uid = 1002
 


### PR DESCRIPTION
## Summary

The jammy stack has no default user or group configured, but with Noble there is a default user and group. These are assigned to uid and gid 1000. The uid was previously changed to 1001 (build) and 1002 (run), but the gid was not changed. This changes the gid to 1001 (from 1000), so that it does not collide with the default gid that is in the image

Here's a comparison of jammy and noble, note how noble has an `ubuntu` group which is 1000. This conflicts with the group id we have defined for the `cnb` group that gets added and causes issues.

```
> podman run --rm -it ubuntu:noble cat /etc/group
root:x:0:
daemon:x:1:
bin:x:2:
sys:x:3:
adm:x:4:ubuntu
tty:x:5:
disk:x:6:
lp:x:7:
mail:x:8:
news:x:9:
uucp:x:10:
man:x:12:
proxy:x:13:
kmem:x:15:
dialout:x:20:ubuntu
fax:x:21:
voice:x:22:
cdrom:x:24:ubuntu
floppy:x:25:ubuntu
tape:x:26:
sudo:x:27:ubuntu
audio:x:29:ubuntu
dip:x:30:ubuntu
www-data:x:33:
backup:x:34:
operator:x:37:
list:x:38:
irc:x:39:
src:x:40:
shadow:x:42:
utmp:x:43:
video:x:44:ubuntu
sasl:x:45:
plugdev:x:46:ubuntu
staff:x:50:
games:x:60:
users:x:100:
nogroup:x:65534:
ubuntu:x:1000:
```

```
> podman run --rm -it ubuntu:jammy cat /etc/group
root:x:0:
daemon:x:1:
bin:x:2:
sys:x:3:
adm:x:4:
tty:x:5:
disk:x:6:
lp:x:7:
mail:x:8:
news:x:9:
uucp:x:10:
man:x:12:
proxy:x:13:
kmem:x:15:
dialout:x:20:
fax:x:21:
voice:x:22:
cdrom:x:24:
floppy:x:25:
tape:x:26:
sudo:x:27:
audio:x:29:
dip:x:30:
www-data:x:33:
backup:x:34:
operator:x:37:
list:x:38:
irc:x:39:
src:x:40:
gnats:x:41:
shadow:x:42:
utmp:x:43:
video:x:44:
sasl:x:45:
plugdev:x:46:
staff:x:50:
games:x:60:
users:x:100:
nogroup:x:65534:
```

Thanks to @ZephireNZ for debugging and pointing this issue out.