### PR TITLE
Add fontconfig to the run image

### DIFF
--- a/stacks/noble-base-stack/stack.toml
+++ b/stacks/noble-base-stack/stack.toml
@@ -90,6 +90,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     openssl \
     tzdata \
     zlib1g \
+    fontconfig
     """
 
     [run.platforms."linux/arm64".args]


### PR DESCRIPTION
## Summary

Adding this allows applications that require font rendering, like PDF generators, to work properly.

This package is being installed with the Jammy base image, so we should retain it for Noble, unless there is a strong reason for not including it.

https://github.com/paketo-buildpacks/jammy-base-stack/blob/main/stack/stack.toml#L77C5-L77C15

The impact to image size is about 6M.

```
docker.io/dmikusa/ubuntu-noble-run-image            arm64-fontconfig  f22e9b6fad42  40 minutes ago  136 MB
docker.io/paketobuildpacks/ubuntu-noble-run         latest            4fbb21bb08a7  2 days ago      130 MB
```

## Use Cases

Support any application that needs fonts to draw text in graphics or PDF files.
