### PR TITLE
Add the libstdc++6 & libgcc-s1 packages

### DIFF
--- a/stacks/noble-tiny-stack/stack.toml
+++ b/stacks/noble-tiny-stack/stack.toml
@@ -87,7 +87,9 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
     netbase \
     openssl \
     tzdata \
-    zlib1g"""
+    zlib1g \
+    libstdc++6 \
+    libgcc-s1"""
 
   [run.platforms."linux/arm64".args]
     architecture = "arm64"


### PR DESCRIPTION
## Summary

This is in accordance with https://github.com/paketo-buildpacks/rfcs/blob/main/text/stacks/0006-node-on-tiny.md which was accepted previously.

