### PR TITLE
Update stack.toml

### DIFF
--- a/stacks/noble-tiny-stack/stack.toml
+++ b/stacks/noble-tiny-stack/stack.toml
@@ -1,4 +1,4 @@
-id = "io.buildpacks.stacks.noble"
+id = "io.buildpacks.stacks.noble.tiny"
 homepage = "https://github.com/paketo-buildpacks/noble-tiny-stack"
 maintainer = "Paketo Buildpacks"
 


### PR DESCRIPTION
## Summary

I believe that the ID here for tiny is wrong. It should have `.tiny` on the end. That is the pattern we've followed in previous versions.

Unless there's a specific reason that we switched this for Noble. I can't recall a reason, and we are using `.static` for the static run image. Can any one recall we did it this way?
